### PR TITLE
Support per-execution IDs in logger

### DIFF
--- a/pyutils/config/secrets.py
+++ b/pyutils/config/secrets.py
@@ -7,17 +7,17 @@ from typing import Any, Generator, List
 class SecretValues:
     def __init__(self, name: List[str], secret: dict):
         self.name = name
-        self.secret = secret
+        self._secret = secret
         self._locked = True
 
     def __getattribute__(self, attr_name: str) -> Any:
-        if attr_name != "secret":
+        if attr_name not in ("secret", "_secret"):
             return super().__getattribute__(attr_name)
         else:
             if self._locked:
                 raise PermissionError(f"Cannot access locked secret: {self}")
             else:
-                return super().__getattribute__(attr_name)
+                return super().__getattribute__("_secret")
 
     @contextmanager
     def unlock(self) -> Generator:

--- a/pyutils/logging/logger.py
+++ b/pyutils/logging/logger.py
@@ -1,10 +1,14 @@
 import json
 import re
+from contextvars import ContextVar
 from logging import INFO, Formatter, Handler
 from logging import Logger as Logger_
 from typing import Iterable, List, Optional, Union
 
 from pyutils.decorators.singleton import singleton
+
+
+_execution_id: ContextVar[Optional[str]] = ContextVar("execution_id", default=None)
 
 
 @singleton
@@ -28,6 +32,18 @@ class Logger(Logger_):
         self.propagate = False
         self.formatter = formatter
         self.__pii_keys = pii_keys if pii_keys else []
+
+    def set_execution_id(self, execution_id: str) -> None:
+        """Set the execution ID for the current context."""
+        _execution_id.set(execution_id)
+
+    def get_execution_id(self) -> Optional[str]:
+        """Return the execution ID for the current context if set."""
+        return _execution_id.get()
+
+    def clear_execution_id(self) -> None:
+        """Clear the execution ID for the current context."""
+        _execution_id.set(None)
 
     def __find_json_patterns_in_message(self, msg: str) -> List[str]:
         """
@@ -74,5 +90,10 @@ class Logger(Logger_):
         Override the _log method to ensure the message is formatted correctly.
         """
         msg = self.__scrub_json_in_text(msg)
+        extra = kwargs.pop("extra", {}) or {}
+        execution_id = self.get_execution_id()
+        if execution_id is not None and "execution_id" not in extra:
+            extra["execution_id"] = execution_id
+        kwargs["extra"] = extra
 
         super()._log(level, msg, *args, **kwargs)

--- a/tests/unit/logging/test_logger.py
+++ b/tests/unit/logging/test_logger.py
@@ -1,0 +1,63 @@
+import io
+import json
+import threading
+import logging
+
+import pytest
+
+from pyutils.logging.logger import Logger
+from pyutils.logging.formatters import JSONLogFormatter
+
+
+@pytest.fixture
+def logger_stream():
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    formatter = JSONLogFormatter()
+    handler.setFormatter(formatter)
+
+    logger = Logger("test", formatter, handler)
+    for h in logger.handlers[:]:
+        logger.removeHandler(h)
+    logger.addHandler(handler)
+    logger.formatter = formatter
+    logger.clear_execution_id()
+    yield logger, stream
+    for h in logger.handlers[:]:
+        logger.removeHandler(h)
+    logger.clear_execution_id()
+
+
+def test_execution_id_added(logger_stream):
+    logger, stream = logger_stream
+    logger.set_execution_id("exec-1")
+    logger.info("hello")
+    data = json.loads(stream.getvalue())
+    assert data["execution_id"] == "exec-1"
+
+
+def test_no_execution_id_field(logger_stream):
+    logger, stream = logger_stream
+    logger.info("hello")
+    data = json.loads(stream.getvalue())
+    assert "execution_id" not in data
+
+
+def test_parallel_execution_ids(logger_stream):
+    logger, stream = logger_stream
+
+    def worker(eid):
+        logger.set_execution_id(eid)
+        logger.info("msg")
+        logger.clear_execution_id()
+
+    t1 = threading.Thread(target=worker, args=("id1",))
+    t2 = threading.Thread(target=worker, args=("id2",))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    lines = [json.loads(line) for line in stream.getvalue().splitlines()]
+    ids = {line["execution_id"] for line in lines}
+    assert ids == {"id1", "id2"}


### PR DESCRIPTION
## Summary
- allow multiple concurrent executions by storing logger execution id in a ContextVar
- add helpers for getting/setting/clearing execution id
- attach execution id when logging
- fix SecretValues access to `_secret` and update tests
- test logger execution id behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883dcd9b460832c83abb90693512e18