### PR TITLE
Add tests for remaining modules

### DIFF
--- a/pyutils/config/providers.py
+++ b/pyutils/config/providers.py
@@ -39,10 +39,12 @@ class FileConfigProvider(ConfigProvider):
                 self.loaded_config = self.file_loader(config_file)
 
         # Declared here because pyre type checks doesn't detect the 'if' test below
-        base_path = self.__base_config_path
-        config_value = None
+        # Access attribute from ConfigProvider; avoid name mangling issues
+        base_path = self._ConfigProvider__base_config_path
         if base_path:
             config_value = get_in(self.loaded_config, base_path + config_path)
+        else:
+            config_value = get_in(self.loaded_config, config_path)
 
         return SecretValues(config_path, config_value)  # type: ignore
 

--- a/tests/unit/config/test_providers.py
+++ b/tests/unit/config/test_providers.py
@@ -1,0 +1,44 @@
+import json
+import yaml
+from pyutils.config.providers import FileConfigProvider, JSONConfigProvider, YAMLConfigProvider
+
+
+def test_file_config_provider_loads_and_caches(tmp_path, mocker):
+    data = {"a": {"b": {"c": 1}}}
+    file_path = tmp_path / "config.json"
+    file_path.write_text(json.dumps(data))
+
+    loader = mocker.Mock(side_effect=[data, Exception("loader called twice")])
+    provider = FileConfigProvider(loader, file_path)
+
+    secret = provider.provide(["a", "b", "c"])
+    with secret.unlock() as sv:
+        assert sv.secret == 1
+
+    # second call should not invoke loader again
+    secret = provider.provide(["a", "b", "c"])
+    with secret.unlock() as sv:
+        assert sv.secret == 1
+    loader.assert_called_once()
+
+
+def test_yaml_config_provider(tmp_path):
+    content = {"outer": {"inner": "val"}}
+    file_path = tmp_path / "config.yaml"
+    file_path.write_text(yaml.safe_dump(content))
+
+    provider = YAMLConfigProvider(file_path, base_config_path=["outer"])
+    secret = provider.provide(["inner"])
+    with secret.unlock() as sv:
+        assert sv.secret == "val"
+
+
+def test_json_config_provider(tmp_path):
+    content = {"outer": {"inner": "val"}}
+    file_path = tmp_path / "config.json"
+    file_path.write_text(json.dumps(content))
+
+    provider = JSONConfigProvider(file_path, base_config_path=["outer"])
+    secret = provider.provide(["inner"])
+    with secret.unlock() as sv:
+        assert sv.secret == "val"

--- a/tests/unit/decorators/test_retry_connection.py
+++ b/tests/unit/decorators/test_retry_connection.py
@@ -1,0 +1,54 @@
+import builtins
+from pyutils.decorators.retry_connection import retry_connection
+from pyutils.decorators.retry_connection import time
+
+
+def test_retry_connection_success_after_retry(mocker):
+    call_count = {"n": 0}
+
+    @retry_connection(retry_count=3, delay=0)
+    def func():
+        call_count["n"] += 1
+        if call_count["n"] < 2:
+            raise ValueError("fail")
+        return "ok"
+
+    sleep = mocker.patch("pyutils.decorators.retry_connection.time.sleep")
+    result = func()
+    assert result == "ok"
+    assert call_count["n"] == 2
+    sleep.assert_called_once_with(0)
+
+
+def test_retry_connection_failure(mocker):
+    @retry_connection(retry_count=2, delay=0)
+    def func():
+        raise ValueError("fail")
+
+    sleep = mocker.patch("pyutils.decorators.retry_connection.time.sleep")
+    result = func()
+    assert result is None
+    sleep.assert_called_once_with(0)
+
+
+def test_retry_connection_jitter_on_exception(mocker):
+    jitter = mocker.patch(
+        "pyutils.decorators.retry_connection.get_jitter_delay_value",
+        return_value=0,
+    )
+    sleep = mocker.patch("pyutils.decorators.retry_connection.time.sleep")
+
+    @retry_connection(
+        retry_count=2,
+        delay=0,
+        add_retry_jitter_exc=[ValueError],
+        min_retry_jitter=1,
+        max_retry_jitter=2,
+    )
+    def func():
+        raise ValueError("fail")
+
+    result = func()
+    assert result is None
+    jitter.assert_called_once_with(1, min_delay=1, max_delay=2)
+    sleep.assert_called_once_with(0)

--- a/tests/unit/decorators/test_singleton.py
+++ b/tests/unit/decorators/test_singleton.py
@@ -1,0 +1,12 @@
+from pyutils.decorators.singleton import singleton
+
+
+@singleton
+class Dummy:
+    pass
+
+
+def test_singleton_same_instance():
+    a = Dummy()
+    b = Dummy()
+    assert a is b

--- a/tests/unit/helpers/test_errors.py
+++ b/tests/unit/helpers/test_errors.py
@@ -1,0 +1,13 @@
+import pytest
+
+from pyutils.helpers.errors import BadArgumentsError, Error
+
+
+def test_error_repr_and_extension_details():
+    err = BadArgumentsError("bad", extra="x")
+    repr_str = repr(err)
+    assert "BadArgumentsError" in repr_str
+    assert "message='bad'" in repr_str
+    details = err.extension_details
+    assert details["extra"] == "x"
+    assert details["code"] == "BadArgumentsError"

--- a/tests/unit/helpers/test_uuid.py
+++ b/tests/unit/helpers/test_uuid.py
@@ -1,0 +1,22 @@
+import uuid
+import pytest
+
+from pyutils.helpers.uuid import is_uuid, validate_uuid, validate_uuids, convert_to_uuid
+from pyutils.helpers.errors import BadArgumentsError
+
+
+def test_uuid_validation_and_conversion():
+    u = str(uuid.uuid4())
+    assert is_uuid(u)
+    assert convert_to_uuid(u) == uuid.UUID(u)
+    validate_uuid(u)
+    validate_uuids([u, u])
+
+    bad = "not-a-uuid"
+    assert not is_uuid(bad)
+    with pytest.raises(BadArgumentsError):
+        validate_uuid(bad)
+    with pytest.raises(BadArgumentsError):
+        validate_uuids([u, bad])
+    with pytest.raises(BadArgumentsError):
+        convert_to_uuid(bad)

--- a/tests/unit/logging/test_handlers_and_formatters.py
+++ b/tests/unit/logging/test_handlers_and_formatters.py
@@ -1,0 +1,81 @@
+import json
+import logging
+import sys
+
+import pytest
+
+from pyutils.logging.formatters import JSONLogFormatter
+from pyutils.logging.handlers import BetterStackHandler, CommandLineHandler
+
+
+def test_json_log_formatter_basic():
+    formatter = JSONLogFormatter()
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=10,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+    record.execution_id = "exec"
+    payload = json.loads(formatter.format(record))
+    assert payload["message"] == "hello"
+    assert payload["level"] == "INFO"
+    assert payload["execution_id"] == "exec"
+
+
+def test_json_log_formatter_with_exception():
+    formatter = JSONLogFormatter()
+    try:
+        1 / 0
+    except ZeroDivisionError:
+        record = logging.LogRecord(
+            name="test",
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=20,
+            msg="boom",
+            args=(),
+            exc_info=sys.exc_info(),
+        )
+        payload = json.loads(formatter.format(record))
+        assert "stack" in payload
+        assert len(payload["stack"]) <= 2000
+
+
+def test_command_line_handler_emits(capsys):
+    handler = CommandLineHandler()
+    handler.setFormatter(logging.Formatter("%(levelname)s:%(message)s"))
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=5,
+        msg="msg",
+        args=(),
+        exc_info=None,
+    )
+    handler.emit(record)
+    captured = capsys.readouterr().out.strip()
+    assert captured == "INFO:msg"
+
+
+def test_better_stack_handler_emits(mocker):
+    handler = BetterStackHandler("API")
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    post = mocker.patch("pyutils.logging.handlers.requests.post")
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=5,
+        msg="msg",
+        args=(),
+        exc_info=None,
+    )
+    handler.emit(record)
+    post.assert_called_once_with(
+        handler.endpoint, headers=handler.headers, data="msg"
+    )


### PR DESCRIPTION
## Summary
- fix `FileConfigProvider.provide` attribute access
- add unit tests for config providers
- add unit tests for decorators
- add unit tests for helpers
- add unit tests for logging formatters and handlers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e733cb6c832ca14e31027f0eb9e5