### PR TITLE
Add delete functionality to DBWrapper

### DIFF
--- a/pyutils/database/sqlalchemy/wrapper.py
+++ b/pyutils/database/sqlalchemy/wrapper.py
@@ -266,6 +266,54 @@ class DBWrapper:
 
         return result
 
+    def _delete_model(
+        self, model: DB.Model, error_message: Optional[str] = None
+    ) -> int:
+        """Delete a single model from the session.
+
+        Parameters
+        ----------
+        model: DB.Model
+            The model instance to delete.
+        error_message: str, optional
+            Custom error message used when the delete fails.
+
+        Returns
+        -------
+        int
+            Number of deleted models. Always ``1`` if no exception is raised.
+        """
+
+        return self._delete_models([model], error_message)
+
+    def _delete_models(
+        self, models: [DB.Model], error_message: Optional[str] = None
+    ) -> int:
+        """Delete multiple models in one session.
+
+        Parameters
+        ----------
+        models: list[DB.Model]
+            List of model instances to delete.
+        error_message: str, optional
+            Custom error message used when the delete fails.
+
+        Returns
+        -------
+        int
+            Number of deleted models.
+        """
+
+        if error_message is None or error_message == "":
+            error_message = f"Error deleting {models}"
+        with self.safe_session_scope(error_message) as session:
+            deleted = 0
+            for model in models:
+                session.delete(model)
+                deleted += 1
+
+        return deleted
+
 
 class DBWrapperWithSubQueries(DBWrapper, ABC):
     def _get_attributes_filters(self, model: DB.Model, attributes: [Attribute]):

--- a/tests/unit/database/sqlalchemy/test_wrapper.py
+++ b/tests/unit/database/sqlalchemy/test_wrapper.py
@@ -1,0 +1,56 @@
+import sys
+import types
+from contextlib import contextmanager
+from unittest.mock import call
+
+import pytest
+
+# Stub external dependencies required by DBWrapper
+dummy_module = types.ModuleType("database_factory")
+dummy_module.DB = types.SimpleNamespace(Model=object, Column=object)
+sys.modules["bepfo.clients.db.fo_store.database_factory"] = dummy_module
+dummy_session_module = types.ModuleType("session_handling")
+dummy_session_module.get_db_session = lambda *args, **kwargs: None
+sys.modules["bepfo.clients.db.utils.session_handling"] = dummy_session_module
+dummy_rds_module = types.ModuleType("rds")
+dummy_rds_module.DBFactory = object
+sys.modules["beppy.helpers.db.rds"] = dummy_rds_module
+
+from pyutils.database.sqlalchemy.wrapper import DBWrapper
+
+
+def _context_manager(session):
+    @contextmanager
+    def _cm(*args, **kwargs):
+        yield session
+
+    return _cm()
+
+
+def test_delete_model(mocker):
+    wrapper = DBWrapper(mocker.Mock())
+    session = mocker.Mock()
+    mocked_scope = mocker.patch.object(wrapper, "safe_session_scope")
+    mocked_scope.return_value = _context_manager(session)
+    model = mocker.Mock()
+
+    result = wrapper._delete_model(model, "err")
+
+    mocked_scope.assert_called_once_with("err")
+    session.delete.assert_called_once_with(model)
+    assert result == 1
+
+
+def test_delete_models(mocker):
+    wrapper = DBWrapper(mocker.Mock())
+    session = mocker.Mock()
+    mocked_scope = mocker.patch.object(wrapper, "safe_session_scope")
+    mocked_scope.return_value = _context_manager(session)
+    models = [mocker.Mock(), mocker.Mock()]
+
+    result = wrapper._delete_models(models, "err")
+
+    mocked_scope.assert_called_once_with("err")
+    session.delete.assert_has_calls([call(models[0]), call(models[1])])
+    assert result == len(models)
+


### PR DESCRIPTION
## Summary
- add `_delete_model` and `_delete_models` helpers in DBWrapper
- test DBWrapper deletion helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885f0f36820832c9d9aa678896dee56