### PR TITLE
Add bulk model creation helper

### DIFF
--- a/pyutils/database/sqlalchemy/wrapper.py
+++ b/pyutils/database/sqlalchemy/wrapper.py
@@ -266,6 +266,31 @@ class DBWrapper:
 
         return result
 
+    def _create_models(
+        self, models: [DB.Model], error_message: Optional[str] = None
+    ) -> [DB.Model]:
+        """Create multiple models in one session.
+
+        Parameters
+        ----------
+        models: list[DB.Model]
+            List of model instances to create.
+        error_message: str, optional
+            Custom error message used when the creation fails.
+
+        Returns
+        -------
+        list[DB.Model]
+            The created models.
+        """
+
+        if error_message is None or error_message == "":
+            error_message = f"Error creating {models}"
+        with self.safe_session_scope(error_message) as session:
+            session.add_all(models)
+
+        return models
+
     def _delete_model(
         self, model: DB.Model, error_message: Optional[str] = None
     ) -> int:

--- a/tests/unit/database/sqlalchemy/test_wrapper.py
+++ b/tests/unit/database/sqlalchemy/test_wrapper.py
@@ -54,3 +54,17 @@ def test_delete_models(mocker):
     session.delete.assert_has_calls([call(models[0]), call(models[1])])
     assert result == len(models)
 
+
+def test_create_models(mocker):
+    wrapper = DBWrapper(mocker.Mock())
+    session = mocker.Mock()
+    mocked_scope = mocker.patch.object(wrapper, "safe_session_scope")
+    mocked_scope.return_value = _context_manager(session)
+    models = [mocker.Mock(), mocker.Mock()]
+
+    result = wrapper._create_models(models, "err")
+
+    mocked_scope.assert_called_once_with("err")
+    session.add_all.assert_called_once_with(models)
+    assert result == models
+


### PR DESCRIPTION
## Summary
- add `_create_models` for bulk model creation in DBWrapper
- test bulk creation helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68863c984a54832cbcae62419020bc52